### PR TITLE
Add plist installer from nginx formula to allow launching from launchd

### DIFF
--- a/openresty.rb
+++ b/openresty.rb
@@ -35,4 +35,27 @@ class Openresty < Formula
 
   end
 
+  def plist; <<-EOS.undent
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+    <plist version="1.0">
+      <dict>
+        <key>Label</key>
+        <string>#{plist_name}</string>
+        <key>RunAtLoad</key>
+        <true/>
+        <key>KeepAlive</key>
+        <false/>
+        <key>ProgramArguments</key>
+        <array>
+            <string>#{opt_prefix}/bin/openresty</string>
+            <string>-g</string>
+            <string>daemon off;</string>
+        </array>
+        <key>WorkingDirectory</key>
+        <string>#{HOMEBREW_PREFIX}</string>
+      </dict>
+    </plist>
+    EOS
+  end
 end


### PR DESCRIPTION
I added the plist installed from the nginx formula in homebrew to allow
launchctl/launchd to manage the startup of openresty.

One nice side-effect of this is that it's easy to setup running as root
to listen on port 80:

```
sudo ln -sfv /usr/local/opt/openresty/*.plist /Library/LaunchDaemons
sudo chown root:wheel /usr/local/opt/openresty/*.plist
sudo launchctl load -w /Library/LaunchDaemons/homebrew.mxcl.openresty.plist
```
