### PR TITLE
Added support for --with-http_addition_module

### DIFF
--- a/nginx-full.rb
+++ b/nginx-full.rb
@@ -47,7 +47,8 @@ class NginxFull < Formula
       ['with-mp4',             'with-http_mp4_module',         'Compile with support for mp4 module'],
       ['with-realip',          'with-http_realip_module',      'Compile with support for real IP module'],
       ['with-perl',            'with-http_perl_module',        'Compile with support for Perl module'],
-      ['with-sub',             'with-http_sub_module',         'Compile with support for HTTP Sub module']
+      ['with-sub',             'with-http_sub_module',         'Compile with support for HTTP Sub module'],
+      ['with-addition',        'with-http_addition_module',    'Compile with support for HTTP Addition module']
     ]
   end
   def options


### PR DESCRIPTION
Turns out this is what I really needed for reverse proxies (node, python, and ruby apps mostly).

This commit adds the HTTP addition module for nginx as documented here http://nginx.org/en/docs/http/ngx_http_addition_module.html 

The command to add HTTP addition module is `--with-addition` in order to maintain uniformity with the other modules/module options.

Hope this helps someone in the future as it did for me.
