### PR TITLE
Update nginx-full.rb

### DIFF
--- a/nginx-full.rb
+++ b/nginx-full.rb
@@ -77,6 +77,7 @@ class NginxFull < Formula
       ['with-mp4-h264-module',    nil,                           'Compile with support for HTTP MP4/H264 Module'],
       ['with-notice-module',      nil,                           'Compile with support for HTTP Notice Module'],
       ['with-subs-filter',        nil,                           'Compile with support for Substitutions Filter Module'],
+      ['with-upload',             nil,                           'Compile with support for Upload module'],
       # Internal modules
       ['with-webdav',            'with-http_dav_module',         'Compile with support for WebDAV module'],
       ['with-debug',             'with-debug',                   'Compile with support for debug log'],
@@ -100,8 +101,7 @@ class NginxFull < Formula
       ['with-xslt',              'with-http_xslt_module',        'Compile with support for XSLT module'],
       ['with-pcre-jit',          'with-pcre-jit',                'Compile with support for JIT in PCRE'],
       ['with-auth-req',          'with-http_auth_request_module','Compile with support for HTTP Auth Request Module'],
-      ['with-mail',              'with-mail',                    'Compile with support for Mail module'],
-      ['with-upload',            'with-upload_module',           'Compile with support for Upload module']
+      ['with-mail',              'with-mail',                    'Compile with support for Mail module']
     ]
   end
   def options


### PR DESCRIPTION
When installing the upload module, it meet a error. 
==> ./configure: error: invalid option "--with-upload-module"
I found a error in formula,
at line 104: " ['with-upload',            'with-upload_module',           'Compile with support for Upload module'],"
Exactly, the "Upload module" is a 3rd module, so the "configure" can't accept it.
I had move it up to the last line of the 3rd party modules group from options_data array and set arr[1] to nil.
Please check it.
