### PR TITLE
Refactor third party module and add new modules.

### DIFF
--- a/consistent-hash-nginx-module.rb
+++ b/consistent-hash-nginx-module.rb
@@ -1,0 +1,14 @@
+require 'formula'
+
+class ConsistentHashNginxModule < Formula
+
+  homepage 'https://github.com/replay/ngx_http_consistent_hash'
+  url 'https://github.com/replay/ngx_http_consistent_hash/archive/master.tar.gz'
+  sha1 '4aff332a839fe6e366d3b5faf21dd4dc81ff2459'
+  version '0.0.1'
+
+  def install
+    (share+'consistent-hash-nginx-module').install Dir['*']
+  end
+
+end

--- a/dav-ext-nginx-module.rb
+++ b/dav-ext-nginx-module.rb
@@ -3,8 +3,8 @@ require 'formula'
 class DavExtNginxModule < Formula
   # NGINX WebDAV missing commands support (PROPFIND & OPTIONS)
   homepage 'https://github.com/arut/nginx-dav-ext-module'
-  url 'https://github.com/arut/nginx-dav-ext-module/archive/master.tar.gz'
-  sha1 '329a06c74194bfe8b5f42126cb752293ccd8e98e'
+  url "https://github.com/arut/nginx-dav-ext-module/archive/v0.0.3.tar.gz"
+  sha1 '80714f9471cb5c8259ecdca9e25eb32f4d581074'
   version '0.0.3'
 
   def install

--- a/extended-status-nginx-module.rb
+++ b/extended-status-nginx-module.rb
@@ -1,0 +1,13 @@
+require 'formula'
+
+class ExtendedStatusNginxModule < Formula
+  homepage 'https://github.com/zealot83/ngx_http_extended_status_module'
+  url 'https://github.com/zealot83/ngx_http_extended_status_module/archive/gh-pages.tar.gz'
+
+  sha1 'ed4a6a62accd23fc85bf2bf5d7a09c21f87267d5'
+
+  def install
+    (share+'extended-status-nginx-module').install Dir['*']
+  end
+
+end

--- a/healthcheck-nginx-module.rb
+++ b/healthcheck-nginx-module.rb
@@ -1,0 +1,14 @@
+require 'formula'
+
+class HealthcheckNginxModule < Formula
+
+  homepage "https://github.com/cep21/healthcheck_nginx_upstreams"
+  url "https://github.com/cep21/healthcheck_nginx_upstreams/archive/master.tar.gz"
+
+  sha1 '4c539aa1bd29ea22406ce352142873d6efbe86c0'
+
+  def install
+    (share+'healthcheck-nginx-module').install Dir['*']
+  end
+
+end

--- a/log-if-nginx-module.rb
+++ b/log-if-nginx-module.rb
@@ -1,0 +1,13 @@
+require 'formula'
+
+class LogIfNginxModule < Formula
+
+  homepage 'https://github.com/cfsego/ngx_log_if'
+  url 'https://github.com/cfsego/ngx_log_if/archive/master.tar.gz'
+  sha1 '8dfb8c0f9358821377c0dea810a49a026aecd405'
+
+  def install
+    (share+'log-if-nginx-module').install Dir['*']
+  end
+
+end

--- a/nginx-full.rb
+++ b/nginx-full.rb
@@ -1,6 +1,39 @@
 require 'formula'
 
+module NginxConstants
+  THIRD_PARTY = {
+    'lua' => 'Compile with support for LUA module',
+    'echo' => 'Compile with support for Echo Module',
+    'auth-digest' => 'Compile with support for Auth Digest Module',
+    'set-misc' => 'Compile with support for Set Misc Module',
+    'redis2' => 'Compile with support for Redis2 Module',
+    'array-var' => 'Compile with support for Array Var Module',
+    'accept-language' => 'Compile with support for Accept Language Module',
+    'accesskey' => 'Compile with support for HTTP Access Key Module',
+    'auth-ldap' => 'Compile with support for Auth LDAP Module',
+    'auth-pam' => 'Compile with support for Auth PAM Module',
+    'cache-purge' => 'Compile with support for Cache Purge Module',
+    'ctpp2' => 'Compile with support for CT++ Module',
+    'headers-more' => 'Compile with support for Headers More Module',
+    'tcp-proxy' => 'Compile with support for TCP proxy',
+    'eval' => 'Compile with support for Eval Module',
+    'fancyindex' => 'Compile with support for Fancy Index Module',
+    'mogilefs' => 'Compile with support for HTTP MogileFS Module',
+    'mp4-h264' => 'Compile with support for HTTP MP4/H264 Module',
+    'notice' => 'Compile with support for HTTP Notice Module',
+    'subs-filter' => 'Compile with support for Substitutions Filter Module',
+    'upload' => 'Compile with support for Upload module',
+    'dav-ext' => 'Compile with support for HTTP WebDav Extended Module',
+    'upstream-hash' => 'Compile with support for Upstream Hash Module',
+    'healthcheck' => 'Compile with support for Healthcheck Module',
+    'log-if' => 'Compile with support for Log-if Module',
+    'pagespeed' => 'Compile with support for Pagespeed',
+   }
+end
+
 class NginxFull < Formula
+  include NginxConstants
+
   homepage 'http://nginx.org/'
   url 'http://nginx.org/download/nginx-1.4.4.tar.gz'
   sha1 '304d5991ccde398af2002c0da980ae240cea9356'
@@ -23,71 +56,23 @@ class NginxFull < Formula
   depends_on 'libxml2' if build.with? 'xslt'
   depends_on 'libxslt' if build.with? 'xslt'
   depends_on 'gd' if build.with? 'image-filter'
-  # 3rd party modules
+
+ # register third party flags
+ THIRD_PARTY.each { | name, desc |
+   depends_on "#{name}-nginx-module" if build.include? "with-#{name}-module"
+ }
+
   depends_on 'ngx-devel-kit' if build.include? 'with-lua-module' or build.include? 'with-array-var-module'
-  depends_on 'lua-nginx-module' if build.include? 'with-lua-module'
-  depends_on 'echo-nginx-module' if build.include? 'with-echo-module'
-  depends_on 'auth-digest-nginx-module' if build.include? 'with-auth-digest'
-  depends_on 'set-misc-nginx-module' if build.include? 'with-set-misc-module'
-  depends_on 'redis2-nginx-module' if build.include? 'with-redis2-module'
-  depends_on 'array-var-nginx-module' if build.include? 'with-array-var-module'
-  depends_on 'accept-language-nginx-module' if build.include? 'with-accept-language'
-  depends_on 'accesskey-nginx-module' if build.include? 'with-accesskey-module'
-  depends_on 'auth-ldap-nginx-module' if build.include? 'with-auth-ldap'
-  depends_on 'auth-pam-nginx-module' if build.include? 'with-auth-pam'
-  depends_on 'cache-purge-nginx-module' if build.include? 'with-cache-purge'
-  depends_on 'ctpp2-nginx-module' if build.include? 'with-ctpp2-module'
-  depends_on 'headers-more-nginx-module' if build.include? 'with-headers-more-module'
-  depends_on 'tcp-proxy-nginx-module' if build.include? 'with-tcp-proxy-module'
-  depends_on 'dav-ext-nginx-module' if build.include? 'with-webdav'
-  depends_on 'eval-nginx-module' if build.include? 'with-eval-module'
-  depends_on 'fancyindex-nginx-module' if build.include? 'with-fancyindex-module'
-  depends_on 'mogilefs-nginx-module' if build.include? 'with-mogilefs-module'
-  depends_on 'mp4-h264-nginx-module' if build.include? 'with-mp4-h264-module'
-  depends_on 'notice-nginx-module' if build.include? 'with-notice-module'
-  depends_on 'subs-filter-nginx-module' if build.include? 'with-subs-filter-module'
-  depends_on 'upload-nginx-module' if build.include? 'with-upload-module'
-  depends_on 'upload-progress-nginx-module' if build.include? 'with-upload-progress-module'
 
   skip_clean 'logs'
 
   # Options
   def options_array
-    option_data = [
-      # 3rd party modules
-      ['with-passenger',          nil,                           'Compile with support for Phusion Passenger module'],
-      ['with-lua-module',         nil,                           'Compile with support for LUA module'],
-      ['with-echo-module',        nil,                           'Compile with support for Echo Module'],
-      ['with-auth-digest',        nil,                           'Compile with support for Auth Digest Module'],
-      ['with-set-misc-module',    nil,                           'Compile with support for Set Misc Module'],
-      ['with-redis2-module',      nil,                           'Compile with support for Redis2 Module'],
-      ['with-array-var-module',   nil,                           'Compile with support for Array Var Module'],
-      ['with-accept-language',    nil,                           'Compile with support for Accept Language Module'],
-      ['with-accesskey-module',   nil,                           'Compile with support for HTTP Access Key Module'],
-      ['with-auth-ldap',          nil,                           'Compile with support for Auth LDAP Module'],
-      ['with-auth-pam',           nil,                           'Compile with support for Auth PAM Module'],
-      ['with-cache-purge',        nil,                           'Compile with support for Cache Purge Module'],
-      ['with-ctpp2-module',       nil,                           'Compile with support for CT++ Module'],
-      ['with-headers-more-module',nil,                           'Compile with support for Headers More Module'],
-      ['with-tcp-proxy-module',   nil,                           'Compile with support for TCP proxy'],
-      ['with-dav-ext-module',     nil,                           'Compile with support for HTTP WebDav Extended Module'],
-      ['with-eval-module',        nil,                           'Compile with support for Eval Module'],
-      ['with-fancyindex-module',  nil,                           'Compile with support for Fancy Index Module'],
-      ['with-mogilefs-module',    nil,                           'Compile with support for HTTP MogileFS Module'],
-      ['with-mp4-h264-module',    nil,                           'Compile with support for HTTP MP4/H264 Module'],
-      ['with-notice-module',      nil,                           'Compile with support for HTTP Notice Module'],
-      ['with-subs-filter-module', nil,                           'Compile with support for Substitutions Filter Module'],
-      ['with-upload-module',      nil,                           'Compile with support for Upload module'],
-      ['with-upload-progress-module', nil,                       'Compile with support for Upload Progrress module'],
-      ['with-php-session-module', nil,                           'Compile with support for Parse PHP Sessions module'],
-      ['with-anti-ddos-module',   nil,                           'Compile with support for Anti-DDoS module'],
-      ['with-captcha-module',     nil,                           'Compile with support for Captcha module'],
-      ['with-autols-module',      nil,                           'Compile with support for Flexible Auto Index module'],
-      ['with-auto-keepalive-module', nil,                        'Compile with support for Auto Disable KeepAlive module'],
-      ['with-ustats-module',      nil,                           'Compile with support for Upstream Statistics (HAProxy style) module'],
-      ['with-ext-status-module',  nil,                           'Compile with support for Extended Status module'],
-      ['with-no-pool-nginx',      nil,                           'Patch disable nginx pool machanism & valgrind memcheck to detect memory issues'],
+    THIRD_PARTY.collect { | name, desc |
+      ["with-#{name}-module", nil, desc]
+    } + [
       # Internal modules
+      ['with-passenger',         nil,                           'Compile with support for Phusion Passenger module'],
       ['with-webdav',            'with-http_dav_module',         'Compile with support for WebDAV module'],
       ['with-debug',             'with-debug',                   'Compile with support for debug log'],
       ['with-spdy',              'with-http_spdy_module',        'Compile with support for SPDY module'],
@@ -113,6 +98,7 @@ class NginxFull < Formula
       ['with-mail',              'with-mail',                    'Compile with support for Mail module']
     ]
   end
+
   def options
     options = []
     options_array.each do |arr|
@@ -190,92 +176,18 @@ class NginxFull < Formula
       args << "--add-module=#{HOMEBREW_PREFIX}/share/lua-nginx-module"
     end
 
-    # Echo module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/echo-nginx-module" if build.include? 'with-echo-module'
+    # add third party flags
+    args += THIRD_PARTY.select { | name, desc |
+      build.with? "#{name}-module"
+    }.collect { | name, desc |
+      "--add-module=#{HOMEBREW_PREFIX}/share/#{name}-nginx-module" 
+    }
 
-    # Set-Misc module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/set-misc-nginx-module" if build.include? 'with-set-misc-module'
+    # upstream hash module
+    args << "--add-module=#{HOMEBREW_PREFIX}/share/upstream-hash-nginx-module" if build.include? "with-upstream-hash-module"
 
-    # Redis2 module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/redis2-nginx-module" if build.include? 'with-redis2-module'
-
-    # Array Var module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/array-var-nginx-module" if build.include? 'with-array-var-module'
-
-    # Accept Language module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/accept-language-nginx-module" if build.include? "with-accept-language"
-
-    # HTTP Access Key module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/accesskey-nginx-module" if build.include? "with-accesskey-module"
-
-    # Auth LDAP Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/auth-ldap-nginx-module" if build.include? "with-auth-ldap"
-
-    # Auth PAM Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/auth-pam-nginx-module" if build.include? "with-auth-pam"
-
-    # Auth Digest Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/auth-digest-nginx-module" if build.include? "with-auth-digest"
-
-    # Cache Purge Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/cache-purge-nginx-module" if build.include? "with-cache-purge"
-
-    # CT++ Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/ctpp2-nginx-module" if build.include? "with-ctpp2-module"
-
-    # Headers More Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/headers-more-nginx-module" if build.include? "with-headers-more-module"
-
-    # TCP proxy Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/tcp-proxy-nginx-module" if build.include? "with-tcp-proxy-module"
-
-    # HTTP WebDav Ext Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/dav-ext-nginx-module" if build.include? "with-webdav"
-
-    # Eval Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/eval-nginx-module" if build.include? "with-eval-module"
-
-    # Fancy Index Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/fancyindex-nginx-module" if build.include? "with-fancyindex-module"
-
-    # HTTP MogileFS Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/mogilefs-nginx-module" if build.include? "with-mogilefs-module"
-
-    # HTTP MP4/H264 Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/mp4-h264-nginx-module" if build.include? "with-mp4-h264-module"
-
-    # HTTP Notice Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/notice-nginx-module" if build.include? "with-notice-module"
-
-    # Substitutions Filter Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/subs-filter-nginx-module" if build.include? "with-subs-filter-module"
-
-    # file upload Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/upload-nginx-module" if build.include? "with-upload-module"
-
-    # file upload progress Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/upload-progress-nginx-module" if build.include? "with-upload-progress-module"
-
-    # Parse PHP Sessions Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/php-session-nginx-module" if build.include? "with-php-session-module"
-
-    # Anti-DDoS Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/anti-ddos-nginx-module" if build.include? "with-anti-ddos-module"
-
-    # Captcha Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/captcha-nginx-module" if build.include? "with-captcha-module"
-
-    # Flexible Auto Index Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/autols-nginx-module" if build.include? "with-autols-module"
-
-    # Flexible Auto Index Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/auto-keepalive-nginx-module" if build.include? "with-auto-keepalive-module"
-
-    # Upstream Statistics (HAProxy style) Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/ustats-nginx-module" if build.include? "with-ustats-module"
-
-    # Extended Status Module
-    args << "--add-module=#{HOMEBREW_PREFIX}/share/ext-status-nginx-module" if build.include? "with-ext-status-module"
+    # consistent hash module
+    args << "--add-module=#{HOMEBREW_PREFIX}/share/consistent-hash-nginx-module" if build.include? "with-consistent-hash-module"
 
     if build.head?
       system "./auto/configure", *args

--- a/pagespeed-nginx-module.rb
+++ b/pagespeed-nginx-module.rb
@@ -1,0 +1,27 @@
+require 'formula'
+
+class PagespeedNginxModule < Formula
+  homepage 'https://github.com/pagespeed/ngx_pagespeed'
+  url 'https://github.com/pagespeed/ngx_pagespeed/archive/v1.7.30.2-beta.tar.gz'
+
+  sha1 '276709d665293b2f529b6f92fb5ade61d4fea08b'
+
+  # base psol library
+  class PsolModule < Formula
+    url 'https://dl.google.com/dl/page-speed/psol/1.7.30.1.tar.gz'
+    sha1 'fd0fa589550a14fa18efb4548943fffa821a45a6'
+  end
+
+  def install
+    PsolModule.new.brew do
+      (share+'pagespeed-nginx-module/psol').install Dir['*']
+    end
+
+    #inreplace 'config' do |s|
+    #  s.gsub! /ngx_addon_dir\/psol/, ''
+    #end
+
+    (share+'pagespeed-nginx-module').install Dir['*']
+  end
+
+end

--- a/subs-filter-nginx-module.rb
+++ b/subs-filter-nginx-module.rb
@@ -7,6 +7,6 @@ class SubsFilterNginxModule < Formula
   version '0.6.3' # devel version without pcre depend
 
   def install
-    (share+'auth-digest-nginx-module').install Dir['*']
+    (share+'subs-filter-nginx-module').install Dir['*']
   end
 end

--- a/tcp-proxy-nginx-module.rb
+++ b/tcp-proxy-nginx-module.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class TcpProxyNginxModule < Formula
   homepage 'https://github.com/yaoweibin/nginx_tcp_proxy_module'
-  url 'https://github.com/yaoweibin/nginx_tcp_proxy_module/archive/9f75bb6.zip'
-  sha1 '07083db4d66bcbf43435b2bd304d5206828e9f1e'
+  url 'https://github.com/yaoweibin/nginx_tcp_proxy_module/archive/v0.26.tar.gz'
+  sha1 '3997b93b6421d0afa69e7fd79a952c16a1f5db1b'
 
   # Fix issue compatibility
   def patches; DATA end

--- a/upstream-hash-nginx-module.rb
+++ b/upstream-hash-nginx-module.rb
@@ -1,0 +1,14 @@
+require 'formula'
+
+class UpstreamHashNginxModule < Formula
+
+  homepage 'https://github.com/evanmiller/nginx_upstream_hash'
+  url 'https://github.com/evanmiller/nginx_upstream_hash/archive/master.tar.gz'
+  sha1 '359c3e7f52266763301b29bdf07edfab3d7c32d9'
+  version '0.0.1'
+
+  def install
+    (share+'upstream-hash-nginx-module').install Dir['*']
+  end
+
+end


### PR DESCRIPTION
Refactored third party module configuration to make it simpler to add new modules. Only a module name and a description are required. This assumes that the only logic required is to check for the flag and add an --add-module flag for that module. For anything more involved, a depends_on line should be used.

This also includes a fix for an outdated shasum for the dav-ext, an incorrect share folder name for the subs-filter module, and adds a few modules.
