### PR TITLE
depends_on 'passenger' --with-passenger

### DIFF
--- a/nginx-full.rb
+++ b/nginx-full.rb
@@ -65,6 +65,7 @@ class NginxFull < Formula
   env :userpaths
 
   depends_on 'pcre'
+  depends_on 'passenger' => :optional
   # SPDY needs openssl >= 1.0.1 for NPN; see:
   # https://tools.ietf.org/agenda/82/slides/tls-3.pdf
   # http://www.openssl.org/news/changelog.html
@@ -235,16 +236,27 @@ class NginxFull < Formula
     end
   end
 
-  def caveats; <<-EOS.undent
+  test do
+    system "#{bin}/nginx", '-t'
+  end
+
+  def passenger_caveats; <<-EOS.undent
+
+    To activate Phusion Passenger, add this to #{etc}/nginx/nginx.conf:
+      passenger_root #{HOMEBREW_PREFIX}/opt/passenger/libexec/lib/phusion_passenger/locations.ini
+      passenger_ruby /usr/bin/ruby
+    EOS
+  end
+
+  def caveats
+    s = <<-EOS.undent
     Docroot is: #{HOMEBREW_PREFIX}/var/www
 
-    The default port has been set to 8080 so that nginx can run without sudo.
-
-    If you want to host pages on your local machine to the wider network you
-    can change the port to 80 in: #{HOMEBREW_PREFIX}/etc/nginx/nginx.conf
-
-    You will then need to run nginx as root: `sudo nginx`.
+    The default port has been set in #{HOMEBREW_PREFIX}/etc/nginx/nginx.conf to 8080 so that
+    nginx can run without sudo.
     EOS
+    s << passenger_caveats if build.include? 'with-passenger'
+    s
   end
 
   def plist; <<-EOS.undent


### PR DESCRIPTION
- current version [homebrew/passenger](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/passenger.rb) 404 binarie `rubyext-ruby`
- add test nginx run
- add caveats
