### PR TITLE
Adds ngx-devel-kit requirement for set-misc-module

### DIFF
--- a/nginx-full.rb
+++ b/nginx-full.rb
@@ -174,6 +174,11 @@ class NginxFull < Formula
       "--with-#{arr[1]}"
     }
 
+    # Set misc module depends on nginx-devel-kit being compiled in
+    if build.with? 'set-misc-module'
+      args << "--add-module=#{HOMEBREW_PREFIX}/share/ngx-devel-kit"
+    end
+
     # Third Party Modules
     args += self.class.third_party_modules.select { |name, desc|
       build.with? "#{name}-module"

--- a/set-misc-nginx-module.rb
+++ b/set-misc-nginx-module.rb
@@ -5,6 +5,8 @@ class SetMiscNginxModule < Formula
   url 'https://github.com/agentzh/set-misc-nginx-module/archive/v0.22rc8.tar.gz'
   sha1 '5754e2c26af8fbf12949dcdd68d8c916a3da8450'
 
+  depends_on 'ngx-devel-kit'
+
   def install
     (share+'set-misc-nginx-module').install Dir['*']
   end


### PR DESCRIPTION
Set misc module requires ngx_devel_kit to be compiled in also (see
http://wiki.nginx.org/HttpSetMiscModule#Installation)

To recreate this issue simply brew install nginx-full --with-set-misc-module. This will result in the following compile time fail

```
error: ngx_devel_kit is required to build ngx_set_misc: please put it before ngx_set_misc.
```

Not sure this is the cleanest way to do this but this fixes the issue locally for me
