### PR TITLE
ignore the nil core module config args. such as: passenger

### DIFF
--- a/nginx-full.rb
+++ b/nginx-full.rb
@@ -175,8 +175,8 @@ class NginxFull < Formula
     args += self.class.core_modules.select { |arr|
       build.with? arr[0]
     }.collect { |arr|
-      "--with-#{arr[1]}"
-    }
+      "--with-#{arr[1]}" if arr[1]
+    }.compact
 
     # Set misc module depends on nginx-devel-kit being compiled in
     if build.with? 'set-misc-module'


### PR DESCRIPTION
when install  `brew install nginx-full --with-passenger`
it will raise `./configure: error: invalid option "--with-"`

because the configure args not ignore nil value

``` ruby
args += self.class.core_modules.select { |arr|
  build.with? arr[0]
}.collect { |arr|
  "--with-#{arr[1]}"
}
```

should be change to

``` ruby
args += self.class.core_modules.select { |arr|
  build.with? arr[0]
}.collect { |arr|
  "--with-#{arr[1]}" if arr[1]
}.compact
```
