### PR TITLE
don’t depned passenger formula

### DIFF
--- a/nginx-full.rb
+++ b/nginx-full.rb
@@ -96,7 +96,6 @@ class NginxFull < Formula
   end
 
   depends_on 'pcre'
-  depends_on 'passenger' => :optional
   depends_on 'geoip' => :optional
   depends_on 'openssl' if build.with? 'spdy'
   depends_on 'libxml2' if build.with? 'xslt'


### PR DESCRIPTION
I use linuxbrew and nginx-full in my server,
but nginx-full is dependency the passenger formula.

I think it shouldn't be restricted only use brew to install passenger.
Many people are using rbenv to manage ruby versions.
They will be installed passenger by `gem install passenger`.

And the current nginx formula, already support find passenger-config in your path.
Just need to remove `depends_on 'passenger'`
