### PR TITLE
upgrade openresty to 1.7.2.1

### DIFF
--- a/openresty.rb
+++ b/openresty.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class Openresty < Formula
   homepage 'http://openresty.org'
-  url 'http://openresty.org/download/ngx_openresty-1.4.2.9.tar.gz'
-  sha1 'd6df036381e88125745475d686643f4bb9830974'
-  version '1.4.2.9'
+  url 'http://openresty.org/download/ngx_openresty-1.7.2.1.tar.gz'
+  sha1 'b54b3e0ff5265be6116817a18e753df595b9e929'
+  version '1.7.2.1'
 
   depends_on "luajit"
   depends_on "pcre"


### PR DESCRIPTION
This builds fine on my machine, but YMMV. OpenResty 1.7.2.1 is the latest version at the moment I'm typing this.
