### PR TITLE
New formula websockify-nginx-module: 0.0.2

### DIFF
--- a/Formula/nginx-full.rb
+++ b/Formula/nginx-full.rb
@@ -90,6 +90,7 @@ class NginxFull < Formula
       "rtmp" => "Compile with support for RTMP Module",
       "dosdetector" => "Compile with support for detecting DoS attacks",
       "push-stream" => "Compile with support for http push stream module",
+      "websockify" => "Compile with support for websockify module",
     }
   end
 

--- a/Formula/websockify-nginx-module.rb
+++ b/Formula/websockify-nginx-module.rb
@@ -1,0 +1,11 @@
+require "formula"
+
+class WebsockifyNginxModule < Formula
+  homepage "https://github.com/tg123/websockify-nginx-module"
+  url "https://github.com/tg123/websockify-nginx-module/archive/v0.0.2.tar.gz"
+  sha1 "70a5eadcc744209f4f2737b6d987f4fa2e50e2ed"
+
+  def install
+    (share+"websockify-nginx-module").install Dir["*"]
+  end
+end


### PR DESCRIPTION
Version 0.0.2 of websockify-nginx-module
The nginx-full formula has been modified to make use of it.
Compiled and tested locally.
Please note that websockify is not the same thing as nginx's existing WebSocket proxying; instead, it is a WebSocket - TCP gateway.