### PR TITLE
add support to compile with ngx_small_light module #49

### DIFF
--- a/Formula/nginx-full.rb
+++ b/Formula/nginx-full.rb
@@ -116,6 +116,8 @@ class NginxFull < Formula
   depends_on "icu4c" if build.with? "xsltproc-module"
   depends_on "libxml2" if build.with? "xsltproc-module"
   depends_on "libxslt" if build.with? "xsltproc-module"
+  depends_on "gd" => :optional
+  depends_on "imlib2" => :optional
 
   self.core_modules.each do |arr|
     option "with-#{arr[0]}", arr[2]
@@ -147,6 +149,17 @@ class NginxFull < Formula
   skip_clean "logs"
 
   def install
+    # small-light needs to run setup script
+    if build.with? "small-light-module"
+      small_light = Formula["small-light-nginx-module"]
+      args = build.used_options.select{|option| ["with-gd", "with-imlib2"].include?(option.name)}
+      origin_dir = Dir.pwd
+      Dir.chdir("#{small_light.share}/#{small_light.name}")
+      system "./setup", *args
+      raise "The small-light setup script couldn't generate config file." if !File.exist?("./config")
+      Dir.chdir(origin_dir)
+    end
+
     # Changes default port to 8080
     inreplace "conf/nginx.conf", "listen       80;", "listen       8080;"
 

--- a/Formula/nginx-full.rb
+++ b/Formula/nginx-full.rb
@@ -90,7 +90,8 @@ class NginxFull < Formula
       "dosdetector" => "Compile with support for detecting DoS attacks",
       "push-stream" => "Compile with support for http push stream module",
       "websockify" => "Compile with support for websockify module",
-      "ajp" => "Compile with support for AJP-protocol"
+      "ajp" => "Compile with support for AJP-protocol",
+      "small-light" => "Compile with support for small light module"
     }
   end
 

--- a/Formula/small-light-nginx-module.rb
+++ b/Formula/small-light-nginx-module.rb
@@ -1,0 +1,27 @@
+class SmallLightNginxModule < Formula
+  homepage "https://github.com/cubicdaiya/ngx_small_light"
+  url "https://github.com/cubicdaiya/ngx_small_light/archive/v0.6.6.tar.gz"
+  sha1 "460354c5ff91f8b8f0a5aff435889f0b5d9648cb"
+  version "0.6.6"
+
+  option "with-gd", "enable GD"
+  option "with-imlib2", "enable Imlib2"
+
+  depends_on "pkg-config"
+  depends_on "imagemagick"
+  depends_on "gd" if build.with? "gd"
+  depends_on "imlib2" if build.with? "imlib2"
+
+  def install
+    args = []
+
+    if build.with? "gd"
+      args << "--with-gd"
+    end
+    if build.with? "imlib2"
+      args << "--with-imlib2"
+    end
+    system "./setup", *args
+    (share+"small-light-nginx-module").install Dir["*"]
+  end
+end

--- a/Formula/small-light-nginx-module.rb
+++ b/Formula/small-light-nginx-module.rb
@@ -1,16 +1,13 @@
 class SmallLightNginxModule < Formula
   homepage "https://github.com/cubicdaiya/ngx_small_light"
   url "https://github.com/cubicdaiya/ngx_small_light/archive/v0.6.6.tar.gz"
-  sha1 "460354c5ff91f8b8f0a5aff435889f0b5d9648cb"
-  version "0.6.6"
+  sha256 "e7852ab5f480bc72f21939ffa5ddff7dcb04e4a6750d5b6ebac874f710bd6f6a"
 
-  option "with-gd", "enable GD"
-  option "with-imlib2", "enable Imlib2"
-
-  depends_on "pkg-config"
   depends_on "imagemagick"
-  depends_on "gd" if build.with? "gd"
-  depends_on "imlib2" if build.with? "imlib2"
+  depends_on "pcre"
+  depends_on "pkg-config" => :build
+  depends_on "gd" => :optional
+  depends_on "imlib2" => :optional
 
   def install
     args = []

--- a/Formula/small-light-nginx-module.rb
+++ b/Formula/small-light-nginx-module.rb
@@ -21,4 +21,8 @@ class SmallLightNginxModule < Formula
     system "./setup", *args
     (share+"small-light-nginx-module").install Dir["*"]
   end
+
+  test do
+    assert File.exist?((share+"small-light-nginx-module/config")), "setup script didn't generate config file."
+  end
 end

--- a/Formula/small-light-nginx-module.rb
+++ b/Formula/small-light-nginx-module.rb
@@ -6,23 +6,8 @@ class SmallLightNginxModule < Formula
   depends_on "imagemagick"
   depends_on "pcre"
   depends_on "pkg-config" => :build
-  depends_on "gd" => :optional
-  depends_on "imlib2" => :optional
 
   def install
-    args = []
-
-    if build.with? "gd"
-      args << "--with-gd"
-    end
-    if build.with? "imlib2"
-      args << "--with-imlib2"
-    end
-    system "./setup", *args
     (share+"small-light-nginx-module").install Dir["*"]
-  end
-
-  test do
-    assert File.exist?((share+"small-light-nginx-module/config")), "setup script didn't generate config file."
   end
 end


### PR DESCRIPTION
To support GD, Imlib2 or both libs, use --with-gd / --with-imlib2 options on installing small-light-nginx-module directory.