### PR TITLE
Add openresty dependency on openssl

### DIFF
--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -4,6 +4,7 @@ class Openresty < Formula
   sha256 "dbcfd21f84431a7d13fe3c3656dcd9dd81236a8f7a114ac8d4afb86665f788bb"
 
   depends_on "pcre"
+  depends_on "openssl"
   depends_on "drizzle" => :optional
   depends_on "postgresql" => :optional
   depends_on "geoip" => :optional


### PR DESCRIPTION
Without this dependency, I was getting the following build error:

```
checking for OpenSSL library ... not found
checking for OpenSSL library in /usr/local/ ... not found
checking for OpenSSL library in /usr/pkg/ ... not found
checking for OpenSSL library in /opt/local/ ... not found

./configure: error: SSL modules require the OpenSSL library.
You can either do not enable the modules, or install the OpenSSL library
into the system, or build the OpenSSL library statically from the source
with nginx by using --with-openssl=<path> option.
```