### PR TITLE
Fix build process of ngx_mruby

### DIFF
--- a/Formula/nginx-full.rb
+++ b/Formula/nginx-full.rb
@@ -183,7 +183,8 @@ class NginxFull < Formula
       system "git", "commit", "-m 'build_config.rb'"
       Dir.chdir("#{mruby.share}/#{mruby.name}")
       system "./configure", "--with-ngx-src-root=#{buildpath}"
-      system "make", "build_mruby", "generate_gems_config"
+      system "make", "build_mruby"
+      system "make", "generate_gems_config"
       rm_rf('.git')
       Dir.chdir(origin_dir)
     end


### PR DESCRIPTION
Hi, I'm ngx_mruby author.

`make build_mruby generate_gems_config` occur compile error because this command can't create mrbgems flags file correctly.

ref: https://github.com/matsumoto-r/ngx_mruby/wiki/Install#or-configure-with---add-modulengx_mruby_src-for-nginx-and-make-it
