### PR TITLE
Make ngx-devel-kit a dependency for mruby

### DIFF
--- a/Formula/mruby-nginx-module.rb
+++ b/Formula/mruby-nginx-module.rb
@@ -6,6 +6,8 @@ class MrubyNginxModule < Formula
 
   bottle :unneeded
 
+  depends_on "ngx-devel-kit"
+
   def install
     (share+"mruby-nginx-module").install Dir["*"]
   end

--- a/Formula/nginx-full.rb
+++ b/Formula/nginx-full.rb
@@ -240,8 +240,8 @@ class NginxFull < Formula
       args << "--with-#{arr[1]}" if build.with?(arr[0]) && arr[1]
     end
 
-    # Set misc module depends on nginx-devel-kit being compiled in
-    if build.with? "set-misc-module"
+    # Set misc module and mruby module both depend on nginx-devel-kit being compiled in
+    if build.with?("set-misc-module") || build.with?("mruby-module")
       args << "--add-module=#{HOMEBREW_PREFIX}/share/ngx-devel-kit"
     end
 


### PR DESCRIPTION
Currently, ngx_mruby doesn't work completely unless you also add `--with-set-misc-module` to the build in order to get the `ngx-devel-kit` module added. 

This adds a dependency for `ngx-devel-kit` to the mruby module and ensures the `--add-module` line is also included when building with mruby. 