### PR TITLE
mruby-nginx-module 0.17.0

### DIFF
--- a/Formula/mruby-nginx-module.rb
+++ b/Formula/mruby-nginx-module.rb
@@ -1,8 +1,8 @@
 class MrubyNginxModule < Formula
   desc "Embed the power of MRuby into Nginx"
   homepage "https://github.com/matsumoto-r/ngx_mruby"
-  url "https://github.com/matsumoto-r/ngx_mruby/archive/v1.16.1.tar.gz"
-  sha256 "99cdf5c514bf009e22aea9fa0511a71067f4a31ea6c37c3766e00936539801de"
+  url "https://github.com/matsumoto-r/ngx_mruby/archive/v1.17.0.tar.gz"
+  sha256 "064758cfdcd9674914963d8bf86939e39e0c693e7783d68b307f4a156a1f9812"
 
   bottle :unneeded
 


### PR DESCRIPTION
ngx_mruby is updated to v.0.17.0.

Sorry for sending 2 PRs (this one and #161 ) but I thought it should be separately.
