### PR TITLE
travis.yml: tweak settings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,10 @@
-language: objective-c
-matrix:
-  include:
-    - env: OSX=10.11
-      os: osx
-      osx_image: xcode7.2
-      rvm: system
-    - env: OSX=10.10
-      os: osx
-      osx_image: xcode7.1
-      rvm: system
-    - env: OSX=10.9
-      os: osx
-      osx_image: beta-xcode6.2
-      rvm: system
+language: ruby
+os: osx
+env: OSX=10.11
+osx_image: xcode7.3
+rvm: system
+
 before_install:
-  - ulimit -n 4096
   - if [ -f ".git/shallow" ]; then travis_retry git fetch --unshallow; fi
   - sudo chown -R $USER $(brew --repo)
   - git -C $(brew --repo) reset --hard origin/master
@@ -26,9 +16,11 @@ before_install:
   - cd $(brew --repo)/Library/Taps/homebrew/homebrew-nginx
   - export TRAVIS_BUILD_DIR="$(brew --repo)/Library/Taps/homebrew/homebrew-nginx"
   - export HOMEBREW_DEVELOPER="1"
-  - env | grep TRAVIS_
+  - ulimit -n 4096
+  
 script:
   - brew test-bot
+
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
General cleanup and use only one OS X worker (as these workers are shared between the Homebrew organisation and Jenkins CI does the bottling for you).