### PR TITLE
[openresty] fix missing openresty binary

### DIFF
--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -29,7 +29,6 @@ class Openresty < Formula
       "--prefix=#{prefix}",
       "--pid-path=#{var}/run/openresty.pid",
       "--lock-path=#{var}/run/openresty.lock",
-      "--sbin-path=#{bin}/openresty",
       "--conf-path=#{etc}/openresty/nginx.conf",
       "--http-log-path=#{var}/log/nginx/access.log",
       "--error-log-path=#{var}/log/nginx/error.log",
@@ -68,6 +67,10 @@ class Openresty < Formula
     # Install
     system "make"
     system "make", "install"
+  end
+  
+  test do
+    system "#{bin}/openresty", '-V'
   end
 
   plist_options :manual => "openresty"


### PR DESCRIPTION
and add a test

openresty 1.10.x changed the build process and sbin-path will actually override already existing binary