### PR TITLE
Build ngx-devel-kit when compiling array-var or lua modules

### DIFF
--- a/Formula/nginx-full.rb
+++ b/Formula/nginx-full.rb
@@ -249,7 +249,7 @@ class NginxFull < Formula
     end
 
     # Set misc module and mruby module both depend on nginx-devel-kit being compiled in
-    if build.with?("set-misc-module") || build.with?("mruby-module")
+    if build.with?("set-misc-module") || build.with?("mruby-module") || build.with?("lua-module") || build.with?("array-var-module")
       args << "--add-module=#{HOMEBREW_PREFIX}/share/ngx-devel-kit"
     end
 


### PR DESCRIPTION
These modules depend on ngx-devel-kit, but don't trigger its inclusion. It
would be nice to have a way to detect this automatically, or have modules set
this flag, instead of needing to keep track in two different places.

Fixes #210.