### PR TITLE
Update link to Homebrew standards in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 ## Contributing
 
 I will accept any modules, but please test them to make sure they fully compile first.
-I will also accept any new formula that conform to [Homebrew standards](https://github.com/Homebrew/brew/blob/master/share/doc/homebrew/Acceptable-Formulae.md) and are related to Nginx.
+I will also accept any new formula that conform to [Homebrew standards](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Formulae.md) and are related to Nginx.


### PR DESCRIPTION
Fix broken link to Homebrew standards in CONTRIBUTING.md.