### PR TITLE
openresty: bundle openssl and debug formula

### DIFF
--- a/Formula/openresty-debug.rb
+++ b/Formula/openresty-debug.rb
@@ -1,7 +1,7 @@
 class OpenrestyDebug < Formula
   desc "Scalable Web Platform by Extending NGINX with Lua"
   homepage "http://openresty.org"
-  VERSION = "1.11.2.2"
+  VERSION = "1.11.2.2".freeze
   url "https://openresty.org/download/openresty-#{VERSION}.tar.gz"
   sha256 "7f9ca62cfa1e4aedf29df9169aed0395fd1b90de254139996e554367db4d5a01"
 

--- a/Formula/openresty-debug.rb
+++ b/Formula/openresty-debug.rb
@@ -1,11 +1,9 @@
-class Openresty < Formula
+class OpenrestyDebug < Formula
   desc "Scalable Web Platform by Extending NGINX with Lua"
   homepage "http://openresty.org"
   VERSION = "1.11.2.2"
   url "https://openresty.org/download/openresty-#{VERSION}.tar.gz"
   sha256 "7f9ca62cfa1e4aedf29df9169aed0395fd1b90de254139996e554367db4d5a01"
-
-  option "with-debug", "Compile with support for debug logging but without proper gdb debugging symbols"
 
   depends_on "pcre"
   depends_on "homebrew/nginx/openresty-openssl"
@@ -23,6 +21,7 @@ class Openresty < Formula
 
     args = %W[
       --prefix=#{prefix}
+      --with-debug
       --with-cc-opt=#{cc_opt}
       --with-ld-opt=#{ld_opt}
       --with-pcre-jit
@@ -53,10 +52,6 @@ class Openresty < Formula
       --with-luajit-xcflags=-DLUAJIT_NUMMODE=2\ -DLUAJIT_ENABLE_LUA52COMPAT
       --with-dtrace-probes
     ]
-
-    if build.with? "debug"
-      args << "--with-debug"
-    end
 
     system "./configure", *args
 

--- a/Formula/openresty-openssl.rb
+++ b/Formula/openresty-openssl.rb
@@ -1,8 +1,7 @@
 class OpenrestyOpenssl < Formula
-  desc "This OpenSSL library build is specifically for OpenResty uses.
-  It may contain custom patches from OpenResty."
+  desc "This OpenSSL library build is specifically for OpenResty uses"
   homepage "https://www.openssl.org/"
-  VERSION = "1.0.2j"
+  VERSION = "1.0.2j".freeze
 
   stable do
     url "https://www.openssl.org/source/openssl-#{VERSION}.tar.gz"
@@ -30,12 +29,12 @@ class OpenrestyOpenssl < Formula
               'zlib_dso = DSO_load(NULL, "/usr/lib/libz.dylib", NULL, DSO_FLAG_NO_NAME_TRANSLATION);'
 
     args = [
-       "no-threads",
-       "shared",
-       "zlib",
-       "-g",
+      "no-threads",
+      "shared",
+      "zlib",
+      "-g",
       "--openssldir=#{prefix}",
-      "--libdir=lib"
+      "--libdir=lib",
     ]
 
     if MacOS.prefer_64_bit?
@@ -49,7 +48,7 @@ class OpenrestyOpenssl < Formula
 
     # Install
     system "make"
-    system "make", "install"
+    system "make", "install", "MANDIR=#{man}"
   end
 
   test do

--- a/Formula/openresty-openssl.rb
+++ b/Formula/openresty-openssl.rb
@@ -1,0 +1,65 @@
+class OpenrestyOpenssl < Formula
+  desc "This OpenSSL library build is specifically for OpenResty uses.
+  It may contain custom patches from OpenResty."
+  homepage "https://www.openssl.org/"
+  VERSION = "1.0.2j"
+
+  stable do
+    url "https://www.openssl.org/source/openssl-#{VERSION}.tar.gz"
+    mirror "https://dl.bintray.com/homebrew/mirror/openssl-1#{VERSION}.tar.gz"
+    mirror "https://www.mirrorservice.org/sites/ftp.openssl.org/source/openssl-#{VERSION}.tar.gz"
+    sha256 "e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431"
+
+    patch do
+      url "https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-1.0.2h-sess_set_get_cb_yield.patch"
+      sha256 "6d6e02c21769784b106b62a146bfbfeac54884e23520c8dd29b74f3e1348d4a1"
+    end
+  end
+
+  def install
+    # OpenSSL will prefer the PERL environment variable if set over $PATH
+    # which can cause some odd edge cases & isn't intended. Unset for safety.
+    ENV.delete("PERL")
+
+    # Load zlib from an explicit path instead of relying on dyld's fallback
+    # path, which is empty in a SIP context. This patch will be unnecessary
+    # when we begin building openssl with no-comp to disable TLS compression.
+    # https://langui.sh/2015/11/27/sip-and-dlopen
+    inreplace "crypto/comp/c_zlib.c",
+              'zlib_dso = DSO_load(NULL, "z", NULL, 0);',
+              'zlib_dso = DSO_load(NULL, "/usr/lib/libz.dylib", NULL, DSO_FLAG_NO_NAME_TRANSLATION);'
+
+    args = [
+       "no-threads",
+       "shared",
+       "zlib",
+       "-g",
+      "--openssldir=#{prefix}",
+      "--libdir=lib"
+    ]
+
+    if MacOS.prefer_64_bit?
+      args << "darwin64-x86_64-cc"
+      args << "enable-ec_nistp_64_gcc_128"
+    else
+      args << "darwin-i386-cc"
+    end
+
+    system "./Configure", *args
+
+    # Install
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    # Check OpenSSL itself functions as expected.
+    (testpath/"testfile.txt").write("This is a test file")
+    expected_checksum = "e2d0fe1585a63ec6009c8016ff8dda8b17719a637405a4e23c0ff81339148249"
+    system "#{bin}/openssl", "dgst", "-sha256", "-out", "checksum.txt", "testfile.txt"
+    open("checksum.txt") do |f|
+      checksum = f.read(100).split("=").last.strip
+      assert_equal checksum, expected_checksum
+    end
+  end
+end

--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -1,7 +1,7 @@
 class Openresty < Formula
   desc "Scalable Web Platform by Extending NGINX with Lua"
   homepage "http://openresty.org"
-  VERSION = "1.11.2.2"
+  VERSION = "1.11.2.2".freeze
   url "https://openresty.org/download/openresty-#{VERSION}.tar.gz"
   sha256 "7f9ca62cfa1e4aedf29df9169aed0395fd1b90de254139996e554367db4d5a01"
 


### PR DESCRIPTION
- use `openresty-openssl` instead of `openssl`  to enable those advanced features like `ssl_session_fetch_by_lua*` and `ssl_session_store_by_lua*`.
- use the same configure args as [`rpm` package](https://github.com/openresty/openresty-packaging/blob/master/rpm/SPECS/openresty.spec) 
- add `skip_clean` for `opm` running as normal