### PR TITLE
nginx 1.13.0 (mainline/devel)

### DIFF
--- a/Formula/nginx-full.rb
+++ b/Formula/nginx-full.rb
@@ -5,6 +5,11 @@ class NginxFull < Formula
   sha256 "b4222e26fdb620a8d3c3a3a8b955e08b713672e1bc5198d1e4f462308a795b30"
   head "http://hg.nginx.org/nginx/", :using => :hg
 
+  devel do
+    url "https://nginx.org/download/nginx-1.13.0.tar.gz"
+    sha256 "79f52ab6550f854e14439369808105b5780079769d7b8db3856be03c683605d7"
+  end
+
   conflicts_with "nginx", :because => "nginx-full symlink with the name for compatibility with nginx"
 
   def self.core_modules


### PR DESCRIPTION
```

Changes with nginx 1.13.0                                        25 Apr 2017

    *) Change: SSL renegotiation is now allowed on backend connections.

    *) Feature: the "rcvbuf" and "sndbuf" parameters of the "listen"
       directives of the mail proxy and stream modules.

    *) Feature: the "return" and "error_page" directives can now be used to
       return 308 redirections.
       Thanks to Simon Leblanc.

    *) Feature: the "TLSv1.3" parameter of the "ssl_protocols" directive.

    *) Feature: when logging signals nginx now logs PID of the process which
       sent the signal.

    *) Bugfix: in memory allocation error handling.

    *) Bugfix: if a server in the stream module listened on a wildcard
       address, the source address of a response UDP datagram could differ
       from the original datagram destination address.
```