### PR TITLE
upgraded OpenResty to 1.13.6.1

### DIFF
--- a/Formula/openresty-debug.rb
+++ b/Formula/openresty-debug.rb
@@ -1,6 +1,6 @@
 class OpenrestyDebug < Formula
   desc "Scalable Web Platform by Extending NGINX with Lua"
-  homepage "http://openresty.org"
+  homepage "https://openresty.org"
   VERSION = "1.13.6.1".freeze
   url "https://openresty.org/download/openresty-#{VERSION}.tar.gz"
   sha256 "d1246e6cfa81098eea56fb88693e980d3e6b8752afae686fab271519b81d696b"

--- a/Formula/openresty-debug.rb
+++ b/Formula/openresty-debug.rb
@@ -1,9 +1,9 @@
 class OpenrestyDebug < Formula
   desc "Scalable Web Platform by Extending NGINX with Lua"
   homepage "http://openresty.org"
-  VERSION = "1.11.2.5".freeze
+  VERSION = "1.13.6.1".freeze
   url "https://openresty.org/download/openresty-#{VERSION}.tar.gz"
-  sha256 "f8cc203e8c0fcd69676f65506a3417097fc445f57820aa8e92d7888d8ad657b9"
+  sha256 "d1246e6cfa81098eea56fb88693e980d3e6b8752afae686fab271519b81d696b"
 
   option "with-postgresql", "Compile with ngx_http_postgres_module"
   option "with-iconv", "Compile with ngx_http_iconv_module"

--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -1,6 +1,6 @@
 class Openresty < Formula
   desc "Scalable Web Platform by Extending NGINX with Lua"
-  homepage "http://openresty.org"
+  homepage "https://openresty.org"
   VERSION = "1.13.6.1".freeze
   url "https://openresty.org/download/openresty-#{VERSION}.tar.gz"
   sha256 "d1246e6cfa81098eea56fb88693e980d3e6b8752afae686fab271519b81d696b"

--- a/Formula/openresty.rb
+++ b/Formula/openresty.rb
@@ -1,9 +1,9 @@
 class Openresty < Formula
   desc "Scalable Web Platform by Extending NGINX with Lua"
   homepage "http://openresty.org"
-  VERSION = "1.11.2.5".freeze
+  VERSION = "1.13.6.1".freeze
   url "https://openresty.org/download/openresty-#{VERSION}.tar.gz"
-  sha256 "f8cc203e8c0fcd69676f65506a3417097fc445f57820aa8e92d7888d8ad657b9"
+  sha256 "d1246e6cfa81098eea56fb88693e980d3e6b8752afae686fab271519b81d696b"
 
   option "with-debug", "Compile with support for debug logging but without proper gdb debugging symbols"
   option "with-postgresql", "Compile with ngx_http_postgres_module"


### PR DESCRIPTION
follow the new version of OpenResty : [https://openresty.org/en/changelog-1013006.html](https://openresty.org/en/changelog-1013006.html)