### PR TITLE
Remove deprecated 'bottle :unneeded'

### DIFF
--- a/Formula/accept-language-nginx-module.rb
+++ b/Formula/accept-language-nginx-module.rb
@@ -4,8 +4,6 @@ class AcceptLanguageNginxModule < Formula
   url "https://github.com/giom/nginx_accept_language_module/tarball/master/giom-nginx_accept_language_module-2f69842.tar.gz"
   sha256 "fbcdf792160a1eff7b9549aeb5209d6e76716ff8e86b05e42c90b2d2f858e011"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/accesskey-nginx-module.rb
+++ b/Formula/accesskey-nginx-module.rb
@@ -4,8 +4,6 @@ class AccesskeyNginxModule < Formula
   url "http://wiki.nginx.org/images/5/51/Nginx-accesskey-2.0.3.tar.gz"
   sha256 "d9e94321e78a02de16c57f3e048fd31059fd8116ed03d6de7180f435c52502b1"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/ajp-nginx-module.rb
+++ b/Formula/ajp-nginx-module.rb
@@ -5,8 +5,6 @@ class AjpNginxModule < Formula
   version "0.3.0"
   sha256 "7b3791275ef87dde153679fa459e84784da09b26d35426d61f5477903584b254"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/anti-ddos-nginx-module.rb
+++ b/Formula/anti-ddos-nginx-module.rb
@@ -5,8 +5,6 @@ class AntiDdosNginxModule < Formula
   version "0.1"
   sha256 "eba0b685f500b963c41155330a7c7f42097a36f8d7a2017c467c5c9ee863a732"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["anddos/*"]
   end

--- a/Formula/array-var-nginx-module.rb
+++ b/Formula/array-var-nginx-module.rb
@@ -4,8 +4,6 @@ class ArrayVarNginxModule < Formula
   url "https://github.com/openresty/array-var-nginx-module/archive/v0.05.tar.gz"
   sha256 "c949d4be6f3442c8e2937046448dc8d8def25c0e0fa6f4e805144cea45eabe80"
 
-  bottle :unneeded
-
   depends_on "ngx-devel-kit"
 
   def install

--- a/Formula/auth-digest-nginx-module.rb
+++ b/Formula/auth-digest-nginx-module.rb
@@ -5,8 +5,6 @@ class AuthDigestNginxModule < Formula
   version "0.2.2"
   sha256 "fe683831f832aae4737de1e1026a4454017c2d5f98cb88b08c5411dc380062f8"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/auth-ldap-nginx-module.rb
+++ b/Formula/auth-ldap-nginx-module.rb
@@ -6,8 +6,6 @@ class AuthLdapNginxModule < Formula
   sha256 "80d6cce9a9877d51dec2f85a11ce7cd25edbd2d605c28bc28687ecc5695229ee"
   head "https://github.com/kvspb/nginx-auth-ldap.git"
 
-  bottle :unneeded
-
   depends_on "openldap"
 
   def install

--- a/Formula/auth-pam-nginx-module.rb
+++ b/Formula/auth-pam-nginx-module.rb
@@ -4,8 +4,6 @@ class AuthPamNginxModule < Formula
   url "https://github.com/stogh/ngx_http_auth_pam_module/archive/v1.5.1.tar.gz"
   sha256 "77676842919134af88a7b4bfca4470223e3a00d287d17c0dbdc9a114a685b6e7"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/auto-keepalive-nginx-module.rb
+++ b/Formula/auto-keepalive-nginx-module.rb
@@ -4,8 +4,6 @@ class AutoKeepaliveNginxModule < Formula
   url "https://github.com/ideal/ngx_http_auto_keepalive/archive/86369fc5f4.tar.gz"
   sha256 "131b2af8a6d36a523058292881171343aa4f82ba1f4ebd29794651e8d5d736e5"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/autols-nginx-module.rb
+++ b/Formula/autols-nginx-module.rb
@@ -4,8 +4,6 @@ class AutolsNginxModule < Formula
   url "https://github.com/DvdKhl/ngx_http_autols_module/archive/e0da4b2ff3.tar.gz"
   sha256 "445c5f3ce494f253afe09de7f418fb076ac9aa5c76083a4186e863156fa9d9fc"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["ngx_http_autols_module/*"]
   end

--- a/Formula/brotli-nginx-module.rb
+++ b/Formula/brotli-nginx-module.rb
@@ -5,8 +5,6 @@ class BrotliNginxModule < Formula
   sha256 "309af9e96c10e80f1884acea96379980979581adc287ce338f084607bd48c185"
   head "https://github.com/eustas/ngx_brotli.git"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/cache-purge-nginx-module.rb
+++ b/Formula/cache-purge-nginx-module.rb
@@ -4,8 +4,6 @@ class CachePurgeNginxModule < Formula
   url "https://github.com/nginx-modules/ngx_cache_purge/archive/2.4.2.tar.gz"
   sha256 "067a10ae2a6d623deed5614d9fc55ec9b380d3b6060fd1e32e71c6f955d11cfc"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/captcha-nginx-module.rb
+++ b/Formula/captcha-nginx-module.rb
@@ -5,8 +5,6 @@ class CaptchaNginxModule < Formula
   version "0.1"
   sha256 "35e701afd0343a7fe167df6b3d546d4a8589e6d5ff1aa9064a8f9ebd936cc50b"
 
-  bottle :unneeded
-
   depends_on "imagemagick"
 
   def install

--- a/Formula/counter-zone-nginx-module.rb
+++ b/Formula/counter-zone-nginx-module.rb
@@ -4,8 +4,6 @@ class CounterZoneNginxModule < Formula
   url "https://github.com/theromis/ngx_counter_zone/archive/4be9e36.tar.gz"
   sha256 "9b841ed09ec39cbe27dab16e017433418c0546fba58bc48d853bed0dcae9e322"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/ctpp2-nginx-module.rb
+++ b/Formula/ctpp2-nginx-module.rb
@@ -5,8 +5,6 @@ class Ctpp2NginxModule < Formula
   sha256 "f8adfecc23e2c23af95df8549ef92fd52598b21506a9d9df2278b2605668d5a6"
   head "svn://svn.vbart.ru/ngx_ctpp2/trunk"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/dav-ext-nginx-module.rb
+++ b/Formula/dav-ext-nginx-module.rb
@@ -4,8 +4,6 @@ class DavExtNginxModule < Formula
   url "https://github.com/arut/nginx-dav-ext-module/archive/v3.0.0.tar.gz"
   sha256 "d2499d94d82d4e4eac8425d799e52883131ae86a956524040ff2fd230ef9f859"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/dosdetector-nginx-module.rb
+++ b/Formula/dosdetector-nginx-module.rb
@@ -5,8 +5,6 @@ class DosdetectorNginxModule < Formula
   version "0.1"
   sha256 "eafac404719c21143e645d24540735f18446f61a8d0dd605b4116f1064741172"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/echo-nginx-module.rb
+++ b/Formula/echo-nginx-module.rb
@@ -5,8 +5,6 @@ class EchoNginxModule < Formula
   sha256 "2e6a03032555f5da1bdff2ae96c96486f447da3da37c117e0f964ae0753d22aa"
   head "https://github.com/openresty/echo-nginx-module.git"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/eval-nginx-module.rb
+++ b/Formula/eval-nginx-module.rb
@@ -4,8 +4,6 @@ class EvalNginxModule < Formula
   url "https://github.com/vkholodkov/nginx-eval-module/archive/1.0.3.tar.gz"
   sha256 "849381433a9020ee1162fa6211b047369fde38dc1a8b5de79f03f8fff2407fe2"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/extended-status-nginx-module.rb
+++ b/Formula/extended-status-nginx-module.rb
@@ -4,8 +4,6 @@ class ExtendedStatusNginxModule < Formula
   url "https://github.com/nginx-modules/ngx_http_extended_status_module/archive/1.1.tar.gz"
   sha256 "054b4c1ecae202991d9bfa4efb8c112a883c0d46a6017a5179dc4243a86f7451"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/fancyindex-nginx-module.rb
+++ b/Formula/fancyindex-nginx-module.rb
@@ -5,8 +5,6 @@ class FancyindexNginxModule < Formula
   sha256 "81698fb0c1ec9f906ce308c055d5d248085caf390f4b92516c1ec93f87c886d4"
   head "https://github.com/aperezdc/ngx-fancyindex.git"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/geoip2-nginx-module.rb
+++ b/Formula/geoip2-nginx-module.rb
@@ -4,8 +4,6 @@ class Geoip2NginxModule < Formula
   url "https://github.com/leev/ngx_http_geoip2_module/archive/2.0.tar.gz"
   sha256 "ebb4652c4f9a2e1ee31fddefc4c93ff78e651a4b2727d3453d026bccbd708d99"
 
-  bottle :unneeded
-
   depends_on "libmaxminddb"
 
   def install

--- a/Formula/headers-more-nginx-module.rb
+++ b/Formula/headers-more-nginx-module.rb
@@ -4,8 +4,6 @@ class HeadersMoreNginxModule < Formula
   url "https://github.com/openresty/headers-more-nginx-module/archive/v0.33.tar.gz"
   sha256 "a3dcbab117a9c103bc1ea5200fc00a7b7d2af97ff7fd525f16f8ac2632e30fbf"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/healthcheck-nginx-module.rb
+++ b/Formula/healthcheck-nginx-module.rb
@@ -5,8 +5,6 @@ class HealthcheckNginxModule < Formula
   version "0.1"
   sha256 "0d1c04b449e4ba383b21d3f718973508a50a77ad8e8003df15f8e9c592c2f540"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/http-accounting-nginx-module.rb
+++ b/Formula/http-accounting-nginx-module.rb
@@ -4,8 +4,6 @@ class HttpAccountingNginxModule < Formula
   url "https://github.com/Lax/ngx_http_accounting_module/archive/v0.5.tar.gz"
   sha256 "f14b8e23b137eebe9e56e84be831c3db3e042b3294a1d99f1ad9d2715e5383f9"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/http-flood-detector-nginx-module.rb
+++ b/Formula/http-flood-detector-nginx-module.rb
@@ -5,8 +5,6 @@ class HttpFloodDetectorNginxModule < Formula
   version "0.1"
   sha256 "d069eaf0a23d94da6e76d96db2242a731252a258b79b95e6b70bf757b3f125e4"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/http-remote-passwd-nginx-module.rb
+++ b/Formula/http-remote-passwd-nginx-module.rb
@@ -4,8 +4,6 @@ class HttpRemotePasswdNginxModule < Formula
   url "https://github.com/x-way/ngx_http_remote_passwd/archive/8f5ccc2b70.tar.gz"
   sha256 "2fb62875d915f87748ebc1308c2c2deee438fc83ba8ca4cd5226bb1d96470240"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/log-if-nginx-module.rb
+++ b/Formula/log-if-nginx-module.rb
@@ -6,8 +6,6 @@ class LogIfNginxModule < Formula
   sha256 "1d10d5265f619f9e012b91a69381f5b057896c6b5a445e18b9857f65b8f2b8a9"
   head "https://github.com/cfsego/ngx_log_if.git"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/lua-nginx-module.rb
+++ b/Formula/lua-nginx-module.rb
@@ -5,8 +5,6 @@ class LuaNginxModule < Formula
   sha256 "9e17e086d0ac74fb72326abb7f2f8274c080b4981cbf358b026307b4088e7148"
   head "https://github.com/openresty/lua-nginx-module.git"
 
-  bottle :unneeded
-
   depends_on "luajit"
   depends_on "ngx-devel-kit"
 

--- a/Formula/mod-zip-nginx-module.rb
+++ b/Formula/mod-zip-nginx-module.rb
@@ -5,8 +5,6 @@ class ModZipNginxModule < Formula
   version "0.2"
   sha256 "48f7803dfe6da9465a5101871ceee584402d055fe1e9c6ecff48cb20d4e9d836"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/mogilefs-nginx-module.rb
+++ b/Formula/mogilefs-nginx-module.rb
@@ -5,8 +5,6 @@ class MogilefsNginxModule < Formula
   sha256 "7ac230d30907f013dff8d435a118619ea6168aa3714dba62c6962d350c6295ae"
   head "https://github.com/vkholodkov/nginx-mogilefs-module.git"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/mp4-h264-nginx-module.rb
+++ b/Formula/mp4-h264-nginx-module.rb
@@ -4,8 +4,6 @@ class Mp4H264NginxModule < Formula
   url "http://h264.code-shop.com/download/nginx_mod_h264_streaming-2.2.7.tar.gz"
   sha256 "6d974ba630cef59de1f60996c66b401264a345d25988a76037c2856cec756c19"
 
-  bottle :unneeded
-
   # Fix issue compatibility
   patch :DATA
 
@@ -21,12 +19,12 @@ index 8d565c9..a8df30e 100644
 +++ b/src/ngx_http_streaming_module.c
 @@ -155,10 +155,6 @@ static ngx_int_t ngx_streaming_handler(ngx_http_request_t *r)
    }
- 
+
    /* TODO: Win32 */
 -  if (r->zero_in_uri)
 -  {
 -    return NGX_DECLINED;
 -  }
- 
+
    rc = ngx_http_discard_request_body(r);
- 
+

--- a/Formula/mruby-nginx-module.rb
+++ b/Formula/mruby-nginx-module.rb
@@ -4,8 +4,6 @@ class MrubyNginxModule < Formula
   url "https://github.com/matsumotory/ngx_mruby/archive/v2.1.0.tar.gz"
   sha256 "8cc50f7bac46fab803d3ce18857dc3164fbfb733d728d75d0015a14756db0606"
 
-  bottle :unneeded
-
   depends_on "ngx-devel-kit"
 
   def install

--- a/Formula/naxsi-nginx-module.rb
+++ b/Formula/naxsi-nginx-module.rb
@@ -5,8 +5,6 @@ class NaxsiNginxModule < Formula
   sha256 "0a66dcadd32432460fab180be9f2efe24e911e3798917b2787ee710e02901eb4"
   head "https://github.com/nbs-system/naxsi.git"
 
-  bottle :unneeded
-
   def install
     cd "naxsi_src" do
       pkgshare.install Dir["*"]

--- a/Formula/nchan-nginx-module.rb
+++ b/Formula/nchan-nginx-module.rb
@@ -5,8 +5,6 @@ class NchanNginxModule < Formula
   sha256 "8bb5d1749af759bb5e9cc5476a9c4b44d51bee6096bb89ab5ff53e85367b490b"
   head "https://github.com/slact/nchan.git"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/ngx-devel-kit.rb
+++ b/Formula/ngx-devel-kit.rb
@@ -5,8 +5,6 @@ class NgxDevelKit < Formula
   sha256 "88e05a99a8a7419066f5ae75966fb1efc409bad4522d14986da074554ae61619"
   head "https://github.com/simpl/ngx_devel_kit.git"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/njs-nginx-module.rb
+++ b/Formula/njs-nginx-module.rb
@@ -5,8 +5,6 @@ class NjsNginxModule < Formula
   sha256 "f41fedff2b82bb021b2389122ba3fc501803a4cfd63344f8b850cd531bf2be30"
   head "https://github.com/nginx/njs.git"
 
-  bottle :unneeded
-
   depends_on "pcre" => :build
   depends_on "readline" => :build
 

--- a/Formula/notice-nginx-module.rb
+++ b/Formula/notice-nginx-module.rb
@@ -5,8 +5,6 @@ class NoticeNginxModule < Formula
   version "0.0.2"
   sha256 "c520f7905f569f1590442a7c3ac3ef54a977fb306f3adb9c2ba008d4481939ac"
 
-  bottle :unneeded
-
   # Fix issue compatibility
   patch :DATA
 

--- a/Formula/php-session-nginx-module.rb
+++ b/Formula/php-session-nginx-module.rb
@@ -5,8 +5,6 @@ class PhpSessionNginxModule < Formula
   version "0.4b"
   sha256 "8b2a6d77571657f60bd4a4e411604ddbe9cbe7cdd33f5537923dfe4254770694"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/push-stream-nginx-module.rb
+++ b/Formula/push-stream-nginx-module.rb
@@ -4,8 +4,6 @@ class PushStreamNginxModule < Formula
   url "https://github.com/wandenberg/nginx-push-stream-module/archive/0.5.4.tar.gz"
   sha256 "5253bb8a804ea679e514137a234637298f044c3ef63c053670bf3802ff3535b1"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/realtime-req-nginx-module.rb
+++ b/Formula/realtime-req-nginx-module.rb
@@ -4,8 +4,6 @@ class RealtimeReqNginxModule < Formula
   url "https://github.com/magicbear/ngx_realtime_request_module/archive/1c89cd3da8.tar.gz"
   sha256 "45bf467e8600487e3c88640f37a7f1cb4a629a39fe8461490607fa52a9ff8e7b"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/redis-nginx-module.rb
+++ b/Formula/redis-nginx-module.rb
@@ -4,8 +4,6 @@ class RedisNginxModule < Formula
   url "https://people.FreeBSD.org/~osa/ngx_http_redis-0.3.9.tar.gz"
   sha256 "21f87540f0a44b23ffa5df16fb3d788bc90803b255ef14f9c26e3847a6f26f46"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/redis2-nginx-module.rb
+++ b/Formula/redis2-nginx-module.rb
@@ -4,8 +4,6 @@ class Redis2NginxModule < Formula
   url "https://github.com/openresty/redis2-nginx-module/archive/v0.15.tar.gz"
   sha256 "d255571bcfb9939b78099df39cb4d42f174d789aec8c8e5e47b93942b0299438"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/rtmp-nginx-module.rb
+++ b/Formula/rtmp-nginx-module.rb
@@ -11,8 +11,6 @@ class RtmpNginxModule < Formula
     sha256 "afa7a32135bc522383b1c1ad9d32284856b7b59113401a5ad00039da015f66e3"
   end
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/set-misc-nginx-module.rb
+++ b/Formula/set-misc-nginx-module.rb
@@ -4,8 +4,6 @@ class SetMiscNginxModule < Formula
   url "https://github.com/openresty/set-misc-nginx-module/archive/v0.32.tar.gz"
   sha256 "f1ad2459c4ee6a61771aa84f77871f4bfe42943a4aa4c30c62ba3f981f52c201"
 
-  bottle :unneeded
-
   depends_on "ngx-devel-kit"
 
   def install

--- a/Formula/small-light-nginx-module.rb
+++ b/Formula/small-light-nginx-module.rb
@@ -4,8 +4,6 @@ class SmallLightNginxModule < Formula
   url "https://github.com/cubicdaiya/ngx_small_light/archive/v0.9.2.tar.gz"
   sha256 "4cf660651d11330a13aab29eb1722bf792d7c3c42e2919a36a1957c4ed0f1533"
 
-  bottle :unneeded
-
   depends_on "imagemagick@6"
   depends_on "pcre"
   depends_on "pkg-config" => :build

--- a/Formula/stream-lua-nginx-module.rb
+++ b/Formula/stream-lua-nginx-module.rb
@@ -7,8 +7,6 @@ class StreamLuaNginxModule < Formula
     depends_on "autoconf" => :build
   end
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/subs-filter-nginx-module.rb
+++ b/Formula/subs-filter-nginx-module.rb
@@ -5,8 +5,6 @@ class SubsFilterNginxModule < Formula
   version "0.6.4"
   sha256 "ed4ddbcf0c434f4a1e97b61251a63ace759792764bd5cb79ff20efe348db8db3"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/tarantool-nginx-module.rb
+++ b/Formula/tarantool-nginx-module.rb
@@ -5,8 +5,6 @@ class TarantoolNginxModule < Formula
   version "2.7"
   sha256 "48d0bd45de57c9c34c836941d79ac53b3d51d715361d447794aecd5e16eacfea"
 
-  bottle :unneeded
-
   depends_on "msgpuck" => :build
   depends_on "cmake" => :build
   depends_on "yajl"

--- a/Formula/tcp-proxy-nginx-module.rb
+++ b/Formula/tcp-proxy-nginx-module.rb
@@ -4,8 +4,6 @@ class TcpProxyNginxModule < Formula
   url "https://github.com/yaoweibin/nginx_tcp_proxy_module/archive/v0.4.5.tar.gz"
   sha256 "5225fa70785b14fcdf14a163d01b094c746b70e5ebad7dc35740af4f6d115390"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/txid-nginx-module.rb
+++ b/Formula/txid-nginx-module.rb
@@ -5,8 +5,6 @@ class TxidNginxModule < Formula
   version "0.2"
   sha256 "c5c14172cf23e572d2258bbbbdf09ae7a81a7b6503ce1a0efe0f76260a9a86c5"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/unzip-nginx-module.rb
+++ b/Formula/unzip-nginx-module.rb
@@ -4,8 +4,6 @@ class UnzipNginxModule < Formula
   url "https://github.com/youzee/nginx-unzip-module/archive/03e582a.tar.gz"
   version "0.1"
   sha256 "49a0bd04ac632842e24c5bbb2fdd9ebe3aa6a753efd5b7e71eb273e5973a5cee"
-
-  bottle :unneeded
   revision 1
 
   def install

--- a/Formula/upload-nginx-module.rb
+++ b/Formula/upload-nginx-module.rb
@@ -5,8 +5,6 @@ class UploadNginxModule < Formula
   version "2.3.0"
   sha256 "c86e318addb9c88d70fdbd58ff1f6ef6f404a93070f6db8017a1f880c97946c4"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/upload-progress-nginx-module.rb
+++ b/Formula/upload-progress-nginx-module.rb
@@ -5,8 +5,6 @@ class UploadProgressNginxModule < Formula
   sha256 "b286689355442657650421d8e8398bd4abf9dbbaade65947bb0cb74a349cc497"
   head "https://github.com/masterzen/nginx-upload-progress-module.git"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/upstream-order-nginx-module.rb
+++ b/Formula/upstream-order-nginx-module.rb
@@ -5,8 +5,6 @@ class UpstreamOrderNginxModule < Formula
   version "0.1"
   sha256 "e5fa35bd3ae20b94b760f396bae1aa56a233db79e881472786503f4a7370db27"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/ustats-nginx-module.rb
+++ b/Formula/ustats-nginx-module.rb
@@ -5,8 +5,6 @@ class UstatsNginxModule < Formula
   version "0.3"
   sha256 "4eb5aadd2129da80d110d6c5a9f6a13485c0a24b5397d183bd24fcbe03125771"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/var-req-speed-nginx-module.rb
+++ b/Formula/var-req-speed-nginx-module.rb
@@ -5,8 +5,6 @@ class VarReqSpeedNginxModule < Formula
   version "0.1"
   sha256 "3473de7c25ecf22e586a59c0e1c078c4546aa1c8a6341d7b4daa628f8abe9839"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/vod-nginx-module.rb
+++ b/Formula/vod-nginx-module.rb
@@ -4,8 +4,6 @@ class VodNginxModule < Formula
   url "https://github.com/kaltura/nginx-vod-module/archive/1.24.tar.gz"
   sha256 "b3cad8e3047556955fa028bcc68e7af46d19343942cb7984ad25e6f44d614ddf"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/vts-nginx-module.rb
+++ b/Formula/vts-nginx-module.rb
@@ -5,8 +5,6 @@ class VtsNginxModule < Formula
   sha256 "17ea41d4083f6d1ab1ab83dad9160eeca66867abe16c5a0421f85a39d7c84b65"
   head "https://github.com/vozlt/nginx-module-vts.git"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/websockify-nginx-module.rb
+++ b/Formula/websockify-nginx-module.rb
@@ -4,8 +4,6 @@ class WebsockifyNginxModule < Formula
   url "https://github.com/tg123/websockify-nginx-module/archive/v0.0.3.tar.gz"
   sha256 "35494258f9db0b113d739f9262bae5a61808e117662fe788d1422282d1ce5672"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end

--- a/Formula/xsltproc-nginx-module.rb
+++ b/Formula/xsltproc-nginx-module.rb
@@ -4,8 +4,6 @@ class XsltprocNginxModule < Formula
   url "https://github.com/yoreek/nginx-xsltproc-module/archive/v0.16.tar.gz"
   sha256 "9003d5aa7bff157577d1f8fb5ee070ee52544fc53c48bb9aa0bdd092e5f39bcf"
 
-  bottle :unneeded
-
   def install
     pkgshare.install Dir["*"]
   end


### PR DESCRIPTION
Remove the deprecated `bottle :unneeded` to avoid generating 'Warning's during `brew update`.

### Have you:

- [x] Followed the guidelines in our [Contributing](https://github.com/denji/homebrew-nginx/blob/master/.github/CONTRIBUTING.md) document?
- [x] Checked to ensure there aren't other open [Pull Requests](https://github.com/denji/homebrew-nginx/pulls) for the same update/change?
- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Removed the `revision` line, if any, when bumping the version number?
- [ ] Added/bumped the `revision` number if the changes affect the precompiled bottles?
- [ ] Not altered the `bottle` section?
- [ ] Checked that the tests still pass?
